### PR TITLE
Rework historical rate response structure; add support for limit & order

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,3 @@
 - [ ] set up email for refresh
 - [ ] add support for limit, sort_order in historical API
 - [ ] investigate whether `MAX_RECORDS_PER_REQUEST` is working (limit doesn't seem to be imposed client-side)
-- [ ] restructure historical response to be less verbose (base/quote currencies)

--- a/README.md
+++ b/README.md
@@ -9,5 +9,4 @@
 - [ ] add transaction to creation
 - [ ] use consistent number of decimal places
 - [ ] set up email for refresh
-- [ ] add support for limit, sort_order in historical API
-- [ ] investigate whether `MAX_RECORDS_PER_REQUEST` is working (limit doesn't seem to be imposed client-side)
+- [ ] add support for sort_order in historical API

--- a/app/api/historical_exchange_rates.py
+++ b/app/api/historical_exchange_rates.py
@@ -31,7 +31,7 @@ class HistoricalExchangeRatesQueryParams(BaseModel):
     quote_currency_code: str
     start_date: date = Field(default_factory=get_default_start_date)
     end_date: date = Field(default_factory=get_default_end_date)
-    limit: int = Field(default=MAX_RECORDS_PER_REQUEST)
+    limit: int = Field(default=MAX_RECORDS_PER_REQUEST, ge=1, le=MAX_RECORDS_PER_REQUEST)
     order: Literal["asc", "desc"] = Field(default="desc")
 
     @field_validator("base_currency_code", "quote_currency_code")

--- a/app/api/historical_exchange_rates.py
+++ b/app/api/historical_exchange_rates.py
@@ -1,5 +1,5 @@
 from datetime import date, timedelta
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
@@ -32,6 +32,7 @@ class HistoricalExchangeRatesQueryParams(BaseModel):
     start_date: date = Field(default_factory=get_default_start_date)
     end_date: date = Field(default_factory=get_default_end_date)
     limit: int = Field(default=MAX_RECORDS_PER_REQUEST)
+    order: Literal["asc", "desc"] = Field(default="desc")
 
     @field_validator("base_currency_code", "quote_currency_code")
     @classmethod
@@ -52,6 +53,8 @@ async def historical_exchange_rates(
     base_currency_code = query_params.base_currency_code
     quote_currency_code = query_params.quote_currency_code
     limit = query_params.limit
+    order = query_params.order
+
     today = date.today()
     validation_errors = []
 
@@ -76,7 +79,7 @@ async def historical_exchange_rates(
         start_date=start_date,
         end_date=end_date,
         limit=limit,
-        sort_order="desc",
+        sort_order=order,
     )
 
     exchange_rate_data = [ExchangeRateData.from_model(exchange_rate) for exchange_rate in exchange_rates]

--- a/app/api/historical_exchange_rates.py
+++ b/app/api/historical_exchange_rates.py
@@ -23,11 +23,15 @@ def get_default_end_date() -> date:
     return date.today()
 
 
+MAX_RECORDS_PER_REQUEST = 1_000
+
+
 class HistoricalExchangeRatesQueryParams(BaseModel):
     base_currency_code: str
     quote_currency_code: str
     start_date: date = Field(default_factory=get_default_start_date)
     end_date: date = Field(default_factory=get_default_end_date)
+    limit: int = Field(default=MAX_RECORDS_PER_REQUEST)
 
     @field_validator("base_currency_code", "quote_currency_code")
     @classmethod
@@ -47,7 +51,7 @@ async def historical_exchange_rates(
     end_date = query_params.end_date
     base_currency_code = query_params.base_currency_code
     quote_currency_code = query_params.quote_currency_code
-
+    limit = query_params.limit
     today = date.today()
     validation_errors = []
 
@@ -71,7 +75,7 @@ async def historical_exchange_rates(
         quote_currency_code=quote_currency_code,
         start_date=start_date,
         end_date=end_date,
-        limit=10_000,
+        limit=limit,
         sort_order="desc",
     )
 

--- a/app/schema/exchange_rate_response.py
+++ b/app/schema/exchange_rate_response.py
@@ -28,3 +28,28 @@ class ExchangeRateResponse(BaseModel):
             base_currency_code=model.base_currency_code,
             quote_currency_code=model.quote_currency_code,
         )
+
+
+class ExchangeRateData(BaseModel):
+    rate: Decimal = Field(gt=0)
+    date: date
+
+    @classmethod
+    def from_model(cls, model: ExchangeRate) -> "ExchangeRateData":
+        return cls(
+            rate=model.rate,
+            date=model.as_of,
+        )
+
+
+class HistoricalExchangeRateResponse(BaseModel):
+    base_currency_code: str
+    quote_currency_code: str
+    data: list[ExchangeRateData]
+
+    @field_validator("base_currency_code", "quote_currency_code")
+    @classmethod
+    def validate_iso_code(cls, v: str) -> str:
+        if not re.match(r"^[A-Z]{3}$", v):
+            raise ValueError("Currency code must be 3 uppercase letters")
+        return v

--- a/tests/api/test_historical_exchange_rates.py
+++ b/tests/api/test_historical_exchange_rates.py
@@ -243,6 +243,77 @@ async def test_api_v1_historical_exchange_rates_with_order_asc(
 
 @pytest.mark.asyncio
 @patch("app.api.historical_exchange_rates.date")
+async def test_api_v1_historical_exchange_rates_with_order_desc(
+    mock_date,
+    async_client: AsyncClient,
+    with_test_exchange_rate_service: ExchangeRateServiceInterface,
+) -> None:
+    fixed_date = date(2024, 4, 5)
+    mock_date.today.return_value = fixed_date
+
+    response = await async_client.get(
+        "/api/v1/historical_exchange_rates",
+        params={"base_currency_code": "USD", "quote_currency_code": "EUR"},
+    )
+    assert response.status_code == 200
+
+    response_json = response.json()
+    assert response_json["base_currency_code"] == "USD"
+    assert response_json["quote_currency_code"] == "EUR"
+
+    data = response_json["data"]
+    assert len(data) == 5
+
+    assert data[0] == {
+        "rate": "1.12",
+        "date": "2024-04-02",
+    }
+    assert data[-1] == {
+        "rate": "1",
+        "date": "2024-01-01",
+    }
+
+
+@pytest.mark.asyncio
+@patch("app.api.historical_exchange_rates.date")
+async def test_api_v1_historical_exchange_rates_with_limit_and_order_asc(
+    mock_date,
+    async_client: AsyncClient,
+    with_test_exchange_rate_service: ExchangeRateServiceInterface,
+) -> None:
+    fixed_date = date(2024, 4, 5)
+    mock_date.today.return_value = fixed_date
+
+    response = await async_client.get(
+        "/api/v1/historical_exchange_rates",
+        params={
+            "base_currency_code": "USD",
+            "quote_currency_code": "EUR",
+            "limit": 2,
+            "order": "asc",
+        },
+    )
+    assert response.status_code == 200
+
+    response_json = response.json()
+    assert response_json["base_currency_code"] == "USD"
+    assert response_json["quote_currency_code"] == "EUR"
+
+    data = response_json["data"]
+    assert len(data) == 2
+
+    assert data[0] == {
+        "rate": "1",
+        "date": "2024-01-01",
+    }
+    assert data[-1] == {
+        "rate": "1.02",
+        "date": "2024-01-02",
+    }
+
+
+@pytest.mark.asyncio
+@patch("app.api.historical_exchange_rates.date")
 async def test_api_v1_historical_exchange_rates_with_start_date_after_today(
     mock_date,
     async_client: AsyncClient,
@@ -319,3 +390,65 @@ async def test_api_v1_historical_exchange_rates_invalid_quote_currency(
     response_detail = response.json()["detail"]
     assert len(response_detail) == 1
     assert response_detail[0]["msg"] == "Value error, Invalid currency code: XYZ"
+
+
+@pytest.mark.asyncio
+async def test_api_v1_historical_exchange_rates_with_invalid_limit(
+    async_client: AsyncClient,
+    with_test_exchange_rate_service: ExchangeRateServiceInterface,
+) -> None:
+    response = await async_client.get(
+        "/api/v1/historical_exchange_rates",
+        params={"base_currency_code": "USD", "quote_currency_code": "EUR", "limit": "-1"},
+    )
+    assert response.status_code == 422
+
+    response_detail = response.json()["detail"]
+    assert len(response_detail) == 1
+    assert response_detail[0]["msg"] == "Input should be greater than or equal to 1"
+
+    response = await async_client.get(
+        "/api/v1/historical_exchange_rates",
+        params={"base_currency_code": "USD", "quote_currency_code": "EUR", "limit": "0"},
+    )
+    assert response.status_code == 422
+
+    response_detail = response.json()["detail"]
+    assert len(response_detail) == 1
+    assert response_detail[0]["msg"] == "Input should be greater than or equal to 1"
+
+    response = await async_client.get(
+        "/api/v1/historical_exchange_rates",
+        params={"base_currency_code": "USD", "quote_currency_code": "EUR", "limit": "999999999"},
+    )
+    assert response.status_code == 422
+
+    response_detail = response.json()["detail"]
+    assert len(response_detail) == 1
+    assert response_detail[0]["msg"] == "Input should be less than or equal to 1000"
+
+    response = await async_client.get(
+        "/api/v1/historical_exchange_rates",
+        params={"base_currency_code": "USD", "quote_currency_code": "EUR", "limit": "INFINITYANDBEYOND"},
+    )
+    assert response.status_code == 422
+
+    response_detail = response.json()["detail"]
+    assert len(response_detail) == 1
+    assert response_detail[0]["msg"] == "Input should be a valid integer, unable to parse string as an integer"
+
+
+@pytest.mark.asyncio
+async def test_api_v1_historical_exchange_rates_with_invalid_order(
+    async_client: AsyncClient,
+    with_test_exchange_rate_service: ExchangeRateServiceInterface,
+) -> None:
+    response = await async_client.get(
+        "/api/v1/historical_exchange_rates",
+        params={"base_currency_code": "USD", "quote_currency_code": "EUR", "order": "random"},
+    )
+    assert response.status_code == 422
+
+    response_detail = response.json()["detail"]
+    assert len(response_detail) == 1
+    assert response_detail[0]["msg"] == "Input should be 'asc' or 'desc'"

--- a/tests/api/test_historical_exchange_rates.py
+++ b/tests/api/test_historical_exchange_rates.py
@@ -206,6 +206,43 @@ async def test_api_v1_historical_exchange_rates_with_limit(
 
 @pytest.mark.asyncio
 @patch("app.api.historical_exchange_rates.date")
+async def test_api_v1_historical_exchange_rates_with_order_asc(
+    mock_date,
+    async_client: AsyncClient,
+    with_test_exchange_rate_service: ExchangeRateServiceInterface,
+) -> None:
+    fixed_date = date(2024, 4, 5)
+    mock_date.today.return_value = fixed_date
+
+    response = await async_client.get(
+        "/api/v1/historical_exchange_rates",
+        params={
+            "base_currency_code": "USD",
+            "quote_currency_code": "EUR",
+            "order": "asc",
+        },
+    )
+    assert response.status_code == 200
+
+    response_json = response.json()
+    assert response_json["base_currency_code"] == "USD"
+    assert response_json["quote_currency_code"] == "EUR"
+
+    data = response_json["data"]
+    assert len(data) == 5
+
+    assert data[0] == {
+        "rate": "1",
+        "date": "2024-01-01",
+    }
+    assert data[-1] == {
+        "rate": "1.12",
+        "date": "2024-04-02",
+    }
+
+
+@pytest.mark.asyncio
+@patch("app.api.historical_exchange_rates.date")
 async def test_api_v1_historical_exchange_rates_with_start_date_after_today(
     mock_date,
     async_client: AsyncClient,

--- a/tests/api/test_historical_exchange_rates.py
+++ b/tests/api/test_historical_exchange_rates.py
@@ -23,20 +23,20 @@ async def test_api_v1_historical_exchange_rates(
     )
     assert response.status_code == 200
 
-    data = response.json()
+    response_json = response.json()
+    assert response_json["base_currency_code"] == "USD"
+    assert response_json["quote_currency_code"] == "EUR"
+
+    data = response_json["data"]
     assert len(data) == 5
 
     assert data[0] == {
         "rate": "1.12",
         "date": "2024-04-02",
-        "base_currency_code": "USD",
-        "quote_currency_code": "EUR",
     }
     assert data[-1] == {
         "rate": "1",
         "date": "2024-01-01",
-        "base_currency_code": "USD",
-        "quote_currency_code": "EUR",
     }
 
 
@@ -60,20 +60,20 @@ async def test_api_v1_historical_exchange_rates_with_start_date(
     )
     assert response.status_code == 200
 
-    data = response.json()
+    response_json = response.json()
+    assert response_json["base_currency_code"] == "USD"
+    assert response_json["quote_currency_code"] == "EUR"
+
+    data = response_json["data"]
     assert len(data) == 3
 
     assert data[0] == {
         "rate": "1.05",
         "date": "2024-01-05",
-        "base_currency_code": "USD",
-        "quote_currency_code": "EUR",
     }
     assert data[-1] == {
         "rate": "1.02",
         "date": "2024-01-02",
-        "base_currency_code": "USD",
-        "quote_currency_code": "EUR",
     }
 
 
@@ -97,20 +97,20 @@ async def test_api_v1_historical_exchange_rates_with_end_date(
     )
     assert response.status_code == 200
 
-    data = response.json()
+    response_json = response.json()
+    assert response_json["base_currency_code"] == "USD"
+    assert response_json["quote_currency_code"] == "EUR"
+
+    data = response_json["data"]
     assert len(data) == 4
 
     assert data[0] == {
         "rate": "1.05",
         "date": "2024-01-05",
-        "base_currency_code": "USD",
-        "quote_currency_code": "EUR",
     }
     assert data[-1] == {
         "rate": "1",
         "date": "2024-01-01",
-        "base_currency_code": "USD",
-        "quote_currency_code": "EUR",
     }
 
 
@@ -130,20 +130,20 @@ async def test_api_v1_historical_exchange_rates_with_start_and_end_date(
     )
     assert response.status_code == 200
 
-    data = response.json()
+    response_json = response.json()
+    assert response_json["base_currency_code"] == "USD"
+    assert response_json["quote_currency_code"] == "EUR"
+
+    data = response_json["data"]
     assert len(data) == 6
 
     assert data[0] == {
         "rate": "0.98",
         "date": "2024-10-10",
-        "base_currency_code": "USD",
-        "quote_currency_code": "EUR",
     }
     assert data[-1] == {
         "rate": "1",
         "date": "2024-01-01",
-        "base_currency_code": "USD",
-        "quote_currency_code": "EUR",
     }
 
 

--- a/tests/api/test_historical_exchange_rates.py
+++ b/tests/api/test_historical_exchange_rates.py
@@ -169,6 +169,43 @@ async def test_api_v1_historical_exchange_rates_with_start_date_after_end_date(
 
 @pytest.mark.asyncio
 @patch("app.api.historical_exchange_rates.date")
+async def test_api_v1_historical_exchange_rates_with_limit(
+    mock_date,
+    async_client: AsyncClient,
+    with_test_exchange_rate_service: ExchangeRateServiceInterface,
+) -> None:
+    fixed_date = date(2024, 4, 5)
+    mock_date.today.return_value = fixed_date
+
+    response = await async_client.get(
+        "/api/v1/historical_exchange_rates",
+        params={
+            "base_currency_code": "USD",
+            "quote_currency_code": "EUR",
+            "limit": 2,
+        },
+    )
+    assert response.status_code == 200
+
+    response_json = response.json()
+    assert response_json["base_currency_code"] == "USD"
+    assert response_json["quote_currency_code"] == "EUR"
+
+    data = response_json["data"]
+    assert len(data) == 2
+
+    assert data[0] == {
+        "rate": "1.02",
+        "date": "2024-01-02",
+    }
+    assert data[-1] == {
+        "rate": "1",
+        "date": "2024-01-01",
+    }
+
+
+@pytest.mark.asyncio
+@patch("app.api.historical_exchange_rates.date")
 async def test_api_v1_historical_exchange_rates_with_start_date_after_today(
     mock_date,
     async_client: AsyncClient,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Historical exchange rates API now supports pagination and ordering, allowing users to specify the number of records returned and the sort order (ascending or descending).
	- API responses for historical data now include structured information with base and quote currency codes and a list of dated exchange rates.
- **Bug Fixes**
	- Improved validation and clarity in API responses for historical exchange rates.
- **Tests**
	- Added tests to verify correct handling of limit and order parameters, including validation of invalid inputs, in the historical exchange rates API.
- **Documentation**
	- Updated the README to reflect changes in supported features and API behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->