### PR TITLE
Increase historical data limit

### DIFF
--- a/app/api/historical_exchange_rates.py
+++ b/app/api/historical_exchange_rates.py
@@ -24,6 +24,7 @@ def get_default_end_date() -> AvailableDate:
 
 
 MAX_RECORDS_PER_REQUEST = 10_000  # TODO: lower this with pagination
+DEFAULT_LIMIT = 1_000
 
 
 class HistoricalExchangeRatesQueryParams(BaseModel):
@@ -31,7 +32,7 @@ class HistoricalExchangeRatesQueryParams(BaseModel):
     quote_currency_code: Currency
     start_date: AvailableDate = Field(default_factory=get_default_start_date)
     end_date: AvailableDate = Field(default_factory=get_default_end_date)
-    limit: int = Field(default=MAX_RECORDS_PER_REQUEST, ge=1, le=MAX_RECORDS_PER_REQUEST)
+    limit: int = Field(default=DEFAULT_LIMIT, ge=1, le=MAX_RECORDS_PER_REQUEST)
     order: Literal["asc", "desc"] = Field(default="desc")
 
 

--- a/app/api/historical_exchange_rates.py
+++ b/app/api/historical_exchange_rates.py
@@ -23,7 +23,7 @@ def get_default_end_date() -> AvailableDate:
     return cast(AvailableDate, date.today())
 
 
-MAX_RECORDS_PER_REQUEST = 1_000
+MAX_RECORDS_PER_REQUEST = 10_000  # TODO: lower this with pagination
 
 
 class HistoricalExchangeRatesQueryParams(BaseModel):

--- a/app/services/exchange_rate_service.py
+++ b/app/services/exchange_rate_service.py
@@ -4,8 +4,6 @@ from typing import Literal
 
 from app.models import Currency, CurrencyPair, ExchangeRate
 
-MAX_RECORDS_PER_REQUEST = 1000
-
 
 class ExchangeRateServiceInterface:
     class Meta:

--- a/tests/api/test_historical_exchange_rates.py
+++ b/tests/api/test_historical_exchange_rates.py
@@ -431,7 +431,7 @@ async def test_api_v1_historical_exchange_rates_with_invalid_limit(
 
     response_detail = response.json()["detail"]
     assert len(response_detail) == 1
-    assert response_detail[0]["msg"] == "Input should be less than or equal to 1000"
+    assert response_detail[0]["msg"] == "Input should be less than or equal to 10000"
 
     response = await async_client.get(
         "/api/v1/historical_exchange_rates",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the maximum number of historical exchange rate records that can be requested at once from 1,000 to 10,000.

- **Bug Fixes**
  - Updated error messages to reflect the new maximum limit for requests.

- **Chores**
  - Improved handling of default and maximum limits for record requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->