### PR TITLE
Use consistent number of decimal places in fakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,5 @@
 
 - [ ] use pydantic for API param validations
 - [ ] add transaction to creation
-- [ ] use consistent number of decimal places
 - [ ] set up email for refresh
 - [ ] update refresh process to handle unsupported currencies gracefullly

--- a/app/services/exchange_rate_service.py
+++ b/app/services/exchange_rate_service.py
@@ -68,7 +68,7 @@ class ExchangeRateService(ExchangeRateServiceInterface):
 
         if base_currency_code == quote_currency_code:
             return ExchangeRate(
-                rate=Decimal(1),
+                rate=Decimal("1.00000000"),
                 as_of=as_of,
                 base_currency_code=base_currency_code,
                 quote_currency_code=quote_currency_code,

--- a/tests/support/factories.py
+++ b/tests/support/factories.py
@@ -22,7 +22,7 @@ def build_exchange_rate(**kwargs: ExchangeRateParams | dict) -> ExchangeRate:
         "as_of": date.today(),
         "base_currency_code": "USD",
         "quote_currency_code": "EUR",
-        "rate": Decimal("0.85"),
+        "rate": Decimal("0.85000000"),
         "data_source": "test",
     }
     attributes = defaults | kwargs
@@ -35,14 +35,14 @@ def build_exchange_rate_pair(**kwargs: ExchangeRateParams | dict) -> tuple[Excha
         "as_of": date.today(),
         "base_currency_code": "USD",
         "quote_currency_code": "EUR",
-        "rate": Decimal("0.85"),
+        "rate": Decimal("0.85000000"),
         "data_source": "test",
     }
     attributes = defaults | kwargs
     inverse_attributes = attributes | {
         "base_currency_code": attributes["quote_currency_code"],
         "quote_currency_code": attributes["base_currency_code"],
-        "rate": Decimal("1") / attributes["rate"],
+        "rate": Decimal("1.00000000") / attributes["rate"],
     }
 
     return build_exchange_rate(**attributes), build_exchange_rate(**inverse_attributes)

--- a/tests/support/mock_exchange_rate_service.py
+++ b/tests/support/mock_exchange_rate_service.py
@@ -33,21 +33,21 @@ class MockExchangeRateService(ExchangeRateServiceInterface):
             return build_exchange_rate(
                 base_currency_code=base_currency_code,
                 quote_currency_code=quote_currency_code,
-                rate=Decimal(1),
+                rate=Decimal("1.00000000"),
                 as_of=as_of,
             )
         elif base_currency_code == "USD" and quote_currency_code == "EUR":
             return build_exchange_rate(
                 base_currency_code=base_currency_code,
                 quote_currency_code=quote_currency_code,
-                rate=Decimal(1.02),
+                rate=Decimal("1.02000000"),
                 as_of=as_of,
             )
         elif base_currency_code == "USD" and quote_currency_code == "GBP":
             return build_exchange_rate(
                 base_currency_code=base_currency_code,
                 quote_currency_code=quote_currency_code,
-                rate=Decimal(1.09),
+                rate=Decimal("1.09000000"),
                 as_of=as_of,
             )
 
@@ -67,49 +67,49 @@ class MockExchangeRateService(ExchangeRateServiceInterface):
                 as_of=date(2024, 1, 1),
                 base_currency_code=base_currency_code,
                 quote_currency_code=quote_currency_code,
-                rate=Decimal(1),
+                rate=Decimal("1.00000000"),
             ),
             build_exchange_rate(
                 as_of=date(2024, 1, 2),
                 base_currency_code=base_currency_code,
                 quote_currency_code=quote_currency_code,
-                rate=Decimal(1.02),
+                rate=Decimal("1.02000000"),
             ),
             build_exchange_rate(
                 as_of=date(2024, 1, 3),
                 base_currency_code=base_currency_code,
                 quote_currency_code=quote_currency_code,
-                rate=Decimal(1.04),
+                rate=Decimal("1.04000000"),
             ),
             build_exchange_rate(
                 as_of=date(2024, 1, 5),
                 base_currency_code=base_currency_code,
                 quote_currency_code=quote_currency_code,
-                rate=Decimal(1.05),
+                rate=Decimal("1.05000000"),
             ),
             build_exchange_rate(
                 as_of=date(2024, 4, 2),
                 base_currency_code=base_currency_code,
                 quote_currency_code=quote_currency_code,
-                rate=Decimal(1.12),
+                rate=Decimal("1.12000000"),
             ),
             build_exchange_rate(
                 as_of=date(2024, 10, 10),
                 base_currency_code=base_currency_code,
                 quote_currency_code=quote_currency_code,
-                rate=Decimal(0.98),
+                rate=Decimal("0.98000000"),
             ),
             build_exchange_rate(
                 as_of=date(2024, 10, 22),
                 base_currency_code=base_currency_code,
                 quote_currency_code=quote_currency_code,
-                rate=Decimal(0.95),
+                rate=Decimal("0.95000000"),
             ),
             build_exchange_rate(
                 as_of=date(2024, 10, 31),
                 base_currency_code=base_currency_code,
                 quote_currency_code=quote_currency_code,
-                rate=Decimal(0.92),
+                rate=Decimal("0.92000000"),
             ),
         ]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced consistency in exchange rate decimal precision by standardizing all rates to eight decimal places across the application and test data.

- **Documentation**
  - Removed a completed TODO item about decimal place consistency from the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->