### PR TITLE
Paginate historical rates API

### DIFF
--- a/app/api/exchange_rates/historical_exchange_rates.py
+++ b/app/api/exchange_rates/historical_exchange_rates.py
@@ -71,7 +71,7 @@ async def historical_exchange_rates(
             detail="; ".join(validation_errors),
         )
 
-    exchange_rates = await exchange_rate_service.get_historical_rates(
+    exchange_rates, total = await exchange_rate_service.get_historical_rates(
         base_currency_code=base_currency_code,
         quote_currency_code=quote_currency_code,
         start_date=start_date,
@@ -80,8 +80,6 @@ async def historical_exchange_rates(
         offset=offset,
         sort_order=order,
     )
-
-    total = len(exchange_rates)  # TODO: get from exchange_rate_service
 
     exchange_rate_data = [ExchangeRateData.from_model(exchange_rate) for exchange_rate in exchange_rates]
 

--- a/app/api/exchange_rates/historical_exchange_rates.py
+++ b/app/api/exchange_rates/historical_exchange_rates.py
@@ -45,13 +45,10 @@ async def historical_exchange_rates(
 ) -> HistoricalExchangeRateResponse:
     start_date = query_params.start_date
     end_date = query_params.end_date
-    limit = query_params.size
-    offset = (query_params.page - 1) * limit
+    size = query_params.size
+    page = query_params.page
+    offset = (query_params.page - 1) * size
     order = query_params.order
-
-    print(f"query_params: {query_params}")
-    print(f"DEFAULT_SIZE: {DEFAULT_SIZE}")
-    print(f"offset: {offset}")
 
     today = date.today()
     validation_errors = []
@@ -79,10 +76,12 @@ async def historical_exchange_rates(
         quote_currency_code=quote_currency_code,
         start_date=start_date,
         end_date=end_date,
-        limit=limit,
+        limit=size,
         offset=offset,
         sort_order=order,
     )
+
+    total = len(exchange_rates)  # TODO: get from exchange_rate_service
 
     exchange_rate_data = [ExchangeRateData.from_model(exchange_rate) for exchange_rate in exchange_rates]
 
@@ -90,4 +89,8 @@ async def historical_exchange_rates(
         base_currency_code=base_currency_code,
         quote_currency_code=quote_currency_code,
         data=exchange_rate_data,
+        total=total,
+        page=page,
+        size=size,
+        pages=(total + size - 1) // size,
     )

--- a/app/api/exchange_rates/historical_exchange_rates.py
+++ b/app/api/exchange_rates/historical_exchange_rates.py
@@ -47,8 +47,9 @@ async def historical_exchange_rates(
     end_date = query_params.end_date
     size = query_params.size
     page = query_params.page
-    offset = (query_params.page - 1) * size
     order = query_params.order
+
+    offset = (page - 1) * size
 
     today = date.today()
     validation_errors = []

--- a/app/api/exchange_rates/historical_exchange_rates.py
+++ b/app/api/exchange_rates/historical_exchange_rates.py
@@ -23,19 +23,19 @@ def get_default_end_date() -> AvailableDate:
     return cast(AvailableDate, date.today())
 
 
-MAX_RECORDS_PER_REQUEST = 10_000  # TODO: lower this with pagination
-DEFAULT_LIMIT = 1_000
+DEFAULT_PAGE = 1
+DEFAULT_SIZE = 1_000
+MAX_RECORDS_PER_REQUEST = DEFAULT_SIZE
 
 
 class HistoricalExchangeRatesQueryParams(BaseModel):
     start_date: AvailableDate = Field(default_factory=get_default_start_date)
     end_date: AvailableDate = Field(default_factory=get_default_end_date)
-    limit: int = Field(default=DEFAULT_LIMIT, ge=1, le=MAX_RECORDS_PER_REQUEST)
-    offset: int = Field(default=0, ge=0)
+    page: int = Field(default=DEFAULT_PAGE, ge=1)
+    size: int = Field(default=DEFAULT_SIZE, ge=1, le=MAX_RECORDS_PER_REQUEST)
     order: Literal["asc", "desc"] = Field(default="desc")
 
 
-# TODO: Add pagination
 @router.get("/{base_currency_code}/{quote_currency_code}/historical")
 async def historical_exchange_rates(
     base_currency_code: Currency,
@@ -45,9 +45,13 @@ async def historical_exchange_rates(
 ) -> HistoricalExchangeRateResponse:
     start_date = query_params.start_date
     end_date = query_params.end_date
-    limit = query_params.limit
-    offset = query_params.offset
+    limit = query_params.size
+    offset = (query_params.page - 1) * limit
     order = query_params.order
+
+    print(f"query_params: {query_params}")
+    print(f"DEFAULT_SIZE: {DEFAULT_SIZE}")
+    print(f"offset: {offset}")
 
     today = date.today()
     validation_errors = []

--- a/app/api/exchange_rates/historical_exchange_rates.py
+++ b/app/api/exchange_rates/historical_exchange_rates.py
@@ -31,6 +31,7 @@ class HistoricalExchangeRatesQueryParams(BaseModel):
     start_date: AvailableDate = Field(default_factory=get_default_start_date)
     end_date: AvailableDate = Field(default_factory=get_default_end_date)
     limit: int = Field(default=DEFAULT_LIMIT, ge=1, le=MAX_RECORDS_PER_REQUEST)
+    offset: int = Field(default=0, ge=0)
     order: Literal["asc", "desc"] = Field(default="desc")
 
 
@@ -45,6 +46,7 @@ async def historical_exchange_rates(
     start_date = query_params.start_date
     end_date = query_params.end_date
     limit = query_params.limit
+    offset = query_params.offset
     order = query_params.order
 
     today = date.today()
@@ -74,6 +76,7 @@ async def historical_exchange_rates(
         start_date=start_date,
         end_date=end_date,
         limit=limit,
+        offset=offset,
         sort_order=order,
     )
 

--- a/app/main.py
+++ b/app/main.py
@@ -43,4 +43,4 @@ app.include_router(api_router)
 
 @app.get("/", include_in_schema=False)
 async def root():
-    return RedirectResponse(url="/docs")
+    return RedirectResponse(url="/redoc")

--- a/app/main.py
+++ b/app/main.py
@@ -42,5 +42,5 @@ app.include_router(api_router)
 
 
 @app.get("/", include_in_schema=False)
-async def root():
+async def root() -> RedirectResponse:
     return RedirectResponse(url="/redoc")

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
 from tortoise.contrib.fastapi import tortoise_exception_handlers
 
 from app.api.routes import router as api_router
@@ -38,3 +39,8 @@ app = FastAPI(
 )
 
 app.include_router(api_router)
+
+
+@app.get("/", include_in_schema=False)
+async def root():
+    return RedirectResponse(url="/docs")

--- a/app/schema/exchange_rate_response.py
+++ b/app/schema/exchange_rate_response.py
@@ -38,3 +38,7 @@ class HistoricalExchangeRateResponse(BaseModel):
     base_currency_code: Currency
     quote_currency_code: Currency
     data: list[ExchangeRateData]
+    total: int
+    page: int
+    size: int
+    pages: int

--- a/app/services/exchange_rate_service.py
+++ b/app/services/exchange_rate_service.py
@@ -38,6 +38,7 @@ class ExchangeRateServiceInterface:
         start_date: date | None = None,
         end_date: date | None = None,
         limit: int | None = None,
+        offset: int | None = None,
         sort_order: Literal["asc", "desc"] = "asc",
     ) -> list[ExchangeRate]:
         raise RuntimeError("Must be implemented")
@@ -107,6 +108,7 @@ class ExchangeRateService(ExchangeRateServiceInterface):
         start_date: date | None = None,
         end_date: date | None = None,
         limit: int | None = None,
+        offset: int | None = None,
         sort_order: Literal["asc", "desc"] = "asc",
     ) -> list[ExchangeRate]:
         if end_date is None:
@@ -127,6 +129,9 @@ class ExchangeRateService(ExchangeRateServiceInterface):
 
         if limit is not None:
             query = query.limit(limit)
+
+        if offset is not None:
+            query = query.offset(offset)
 
         if sort_order == "desc":
             query = query.order_by("-as_of")

--- a/app/tasks/notifications.py
+++ b/app/tasks/notifications.py
@@ -18,7 +18,7 @@ async def send_exchange_rate_refresh_email(
         logger.warning("No admin email found")
         return
 
-    exchange_rates = await exchange_rate_service.get_historical_rates(
+    exchange_rates, _total = await exchange_rate_service.get_historical_rates(
         base_currency_code=base_currency,
         quote_currency_code=quote_currency,
         limit=2,

--- a/tests/api/exchange_rates/test_historical_exchange_rates.py
+++ b/tests/api/exchange_rates/test_historical_exchange_rates.py
@@ -156,7 +156,7 @@ async def test_api_v1_historical_exchange_rates_with_limit(
     fixed_date = date(2024, 4, 5)
     mock_date.today.return_value = fixed_date
 
-    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"limit": 2})
+    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"size": 2})
     assert response.status_code == 200
 
     response_json = response.json()
@@ -178,36 +178,6 @@ async def test_api_v1_historical_exchange_rates_with_limit(
 
 @pytest.mark.asyncio
 @patch("app.api.exchange_rates.historical_exchange_rates.date")
-async def test_api_v1_historical_exchange_rates_with_offset(
-    mock_date: MagicMock,
-    async_client: AsyncClient,
-    with_test_exchange_rate_service: ExchangeRateServiceInterface,
-) -> None:
-    fixed_date = date(2024, 4, 5)
-    mock_date.today.return_value = fixed_date
-
-    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"offset": 2})
-    assert response.status_code == 200
-
-    response_json = response.json()
-    assert response_json["base_currency_code"] == "USD"
-    assert response_json["quote_currency_code"] == "EUR"
-
-    data = response_json["data"]
-    assert len(data) == 3
-
-    assert data[0] == {
-        "rate": "1.12",
-        "date": "2024-04-02",
-    }
-    assert data[-1] == {
-        "rate": "1.04",
-        "date": "2024-01-03",
-    }
-
-
-@pytest.mark.asyncio
-@patch("app.api.exchange_rates.historical_exchange_rates.date")
 async def test_api_v1_historical_exchange_rates_with_offset_and_limit(
     mock_date: MagicMock,
     async_client: AsyncClient,
@@ -216,7 +186,7 @@ async def test_api_v1_historical_exchange_rates_with_offset_and_limit(
     fixed_date = date(2024, 4, 5)
     mock_date.today.return_value = fixed_date
 
-    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"offset": 2, "limit": 2})
+    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"page": 2, "size": 2})
     assert response.status_code == 200
 
     response_json = response.json()
@@ -306,7 +276,7 @@ async def test_api_v1_historical_exchange_rates_with_limit_and_order_asc(
     fixed_date = date(2024, 4, 5)
     mock_date.today.return_value = fixed_date
 
-    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"limit": 2, "order": "asc"})
+    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"size": 2, "order": "asc"})
     assert response.status_code == 200
 
     response_json = response.json()
@@ -408,37 +378,35 @@ async def test_api_v1_historical_exchange_rates_with_invalid_limit(
     async_client: AsyncClient,
     with_test_exchange_rate_service: ExchangeRateServiceInterface,
 ) -> None:
-    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"limit": "-1"})
+    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"size": "-1"})
     assert response.status_code == 422
 
     response_detail = response.json()["detail"]
     assert len(response_detail) == 1
     assert response_detail[0]["msg"] == "Input should be greater than or equal to 1"
 
-    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"limit": "0"})
+    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"size": "0"})
     assert response.status_code == 422
 
     response_detail = response.json()["detail"]
     assert len(response_detail) == 1
     assert response_detail[0]["msg"] == "Input should be greater than or equal to 1"
 
-    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"limit": "999999999"})
+    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"size": "999999999"})
     assert response.status_code == 422
 
     response_detail = response.json()["detail"]
     assert len(response_detail) == 1
-    assert response_detail[0]["msg"] == "Input should be less than or equal to 10000"
+    assert response_detail[0]["msg"] == "Input should be less than or equal to 1000"
 
-    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"limit": "3.14159"})
+    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"size": "3.14159"})
     assert response.status_code == 422
 
     response_detail = response.json()["detail"]
     assert len(response_detail) == 1
     assert response_detail[0]["msg"] == "Input should be a valid integer, unable to parse string as an integer"
 
-    response = await async_client.get(
-        "/api/v1/exchange_rates/USD/EUR/historical", params={"limit": "INFINITYANDBEYOND"}
-    )
+    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"size": "INFINITYANDBEYOND"})
     assert response.status_code == 422
 
     response_detail = response.json()["detail"]

--- a/tests/api/exchange_rates/test_historical_exchange_rates.py
+++ b/tests/api/exchange_rates/test_historical_exchange_rates.py
@@ -23,6 +23,10 @@ async def test_api_v1_historical_exchange_rates(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
+    assert response_json["total"] == 5
+    assert response_json["page"] == 1
+    assert response_json["size"] == 5
+    assert response_json["pages"] == 1
 
     data = response_json["data"]
     assert len(data) == 5
@@ -53,6 +57,10 @@ async def test_api_v1_historical_exchange_rates_with_start_date(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
+    assert response_json["total"] == 5
+    assert response_json["page"] == 1
+    assert response_json["size"] == 5
+    assert response_json["pages"] == 1
 
     data = response_json["data"]
     assert len(data) == 3
@@ -83,6 +91,10 @@ async def test_api_v1_historical_exchange_rates_with_end_date(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
+    assert response_json["total"] == 5
+    assert response_json["page"] == 1
+    assert response_json["size"] == 5
+    assert response_json["pages"] == 1
 
     data = response_json["data"]
     assert len(data) == 4
@@ -114,6 +126,10 @@ async def test_api_v1_historical_exchange_rates_with_start_and_end_date(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
+    assert response_json["total"] == 5
+    assert response_json["page"] == 1
+    assert response_json["size"] == 5
+    assert response_json["pages"] == 1
 
     data = response_json["data"]
     assert len(data) == 6
@@ -162,6 +178,10 @@ async def test_api_v1_historical_exchange_rates_with_limit(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
+    assert response_json["total"] == 5
+    assert response_json["page"] == 1
+    assert response_json["size"] == 2
+    assert response_json["pages"] == 3
 
     data = response_json["data"]
     assert len(data) == 2
@@ -192,6 +212,10 @@ async def test_api_v1_historical_exchange_rates_with_offset_and_limit(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
+    assert response_json["total"] == 5
+    assert response_json["page"] == 2
+    assert response_json["size"] == 2
+    assert response_json["pages"] == 3
 
     data = response_json["data"]
     assert len(data) == 2
@@ -222,6 +246,10 @@ async def test_api_v1_historical_exchange_rates_with_order_asc(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
+    assert response_json["total"] == 5
+    assert response_json["page"] == 1
+    assert response_json["size"] == 5
+    assert response_json["pages"] == 1
 
     data = response_json["data"]
     assert len(data) == 5
@@ -252,6 +280,10 @@ async def test_api_v1_historical_exchange_rates_with_order_desc(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
+    assert response_json["total"] == 5
+    assert response_json["page"] == 1
+    assert response_json["size"] == 5
+    assert response_json["pages"] == 1
 
     data = response_json["data"]
     assert len(data) == 5
@@ -282,6 +314,10 @@ async def test_api_v1_historical_exchange_rates_with_limit_and_order_asc(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
+    assert response_json["total"] == 5
+    assert response_json["page"] == 1
+    assert response_json["size"] == 2
+    assert response_json["pages"] == 3
 
     data = response_json["data"]
     assert len(data) == 2

--- a/tests/api/exchange_rates/test_historical_exchange_rates.py
+++ b/tests/api/exchange_rates/test_historical_exchange_rates.py
@@ -2,9 +2,44 @@ from datetime import date
 from unittest.mock import MagicMock, patch
 
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, Response
 
 from app.services.exchange_rate_service import ExchangeRateServiceInterface
+
+
+def assert_historical_exchange_rates_response(
+    response: Response,
+    first_data: dict,
+    last_data: dict,
+    total: int = 8,
+    data_size: int = 5,
+    size: int = 1000,
+    page: int = 1,
+    pages: int = 1,
+) -> None:
+    response_json = response.json()
+    assert response_json.keys() == {
+        "base_currency_code",
+        "quote_currency_code",
+        "data",
+        "total",
+        "page",
+        "size",
+        "pages",
+    }
+
+    assert response_json["base_currency_code"] == "USD"
+    assert response_json["quote_currency_code"] == "EUR"
+    assert response_json["total"] == total
+    assert response_json["size"] == size
+    assert response_json["page"] == page
+    assert response_json["pages"] == pages
+
+    data = response_json["data"]
+    assert len(data) == data_size
+
+    assert data[0] == first_data
+    assert data[-1] == last_data
 
 
 @pytest.mark.asyncio
@@ -20,25 +55,17 @@ async def test_api_v1_historical_exchange_rates(
     response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical")
     assert response.status_code == 200
 
-    response_json = response.json()
-    assert response_json["base_currency_code"] == "USD"
-    assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 8
-    assert response_json["page"] == 1
-    assert response_json["size"] == 1000
-    assert response_json["pages"] == 1
-
-    data = response_json["data"]
-    assert len(data) == 5
-
-    assert data[0] == {
-        "rate": "1.12",
-        "date": "2024-04-02",
-    }
-    assert data[-1] == {
-        "rate": "1",
-        "date": "2024-01-01",
-    }
+    assert_historical_exchange_rates_response(
+        response,
+        first_data={
+            "rate": "1.12",
+            "date": "2024-04-02",
+        },
+        last_data={
+            "rate": "1",
+            "date": "2024-01-01",
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -54,25 +81,18 @@ async def test_api_v1_historical_exchange_rates_with_start_date(
     response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"start_date": "2024-01-02"})
     assert response.status_code == 200
 
-    response_json = response.json()
-    assert response_json["base_currency_code"] == "USD"
-    assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 8
-    assert response_json["page"] == 1
-    assert response_json["size"] == 1000
-    assert response_json["pages"] == 1
-
-    data = response_json["data"]
-    assert len(data) == 3
-
-    assert data[0] == {
-        "rate": "1.05",
-        "date": "2024-01-05",
-    }
-    assert data[-1] == {
-        "rate": "1.02",
-        "date": "2024-01-02",
-    }
+    assert_historical_exchange_rates_response(
+        response,
+        data_size=3,
+        first_data={
+            "rate": "1.05",
+            "date": "2024-01-05",
+        },
+        last_data={
+            "rate": "1.02",
+            "date": "2024-01-02",
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -88,25 +108,18 @@ async def test_api_v1_historical_exchange_rates_with_end_date(
     response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"end_date": "2024-01-05"})
     assert response.status_code == 200
 
-    response_json = response.json()
-    assert response_json["base_currency_code"] == "USD"
-    assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 8
-    assert response_json["page"] == 1
-    assert response_json["size"] == 1000
-    assert response_json["pages"] == 1
-
-    data = response_json["data"]
-    assert len(data) == 4
-
-    assert data[0] == {
-        "rate": "1.05",
-        "date": "2024-01-05",
-    }
-    assert data[-1] == {
-        "rate": "1",
-        "date": "2024-01-01",
-    }
+    assert_historical_exchange_rates_response(
+        response,
+        data_size=4,
+        first_data={
+            "rate": "1.05",
+            "date": "2024-01-05",
+        },
+        last_data={
+            "rate": "1",
+            "date": "2024-01-01",
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -123,43 +136,18 @@ async def test_api_v1_historical_exchange_rates_with_start_and_end_date(
     )
     assert response.status_code == 200
 
-    response_json = response.json()
-    assert response_json["base_currency_code"] == "USD"
-    assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 8
-    assert response_json["page"] == 1
-    assert response_json["size"] == 1000
-    assert response_json["pages"] == 1
-
-    data = response_json["data"]
-    assert len(data) == 6
-
-    assert data[0] == {
-        "rate": "0.98",
-        "date": "2024-10-10",
-    }
-    assert data[-1] == {
-        "rate": "1",
-        "date": "2024-01-01",
-    }
-
-
-@pytest.mark.asyncio
-async def test_api_v1_historical_exchange_rates_with_start_date_after_end_date(
-    async_client: AsyncClient,
-    with_test_exchange_rate_service: ExchangeRateServiceInterface,
-) -> None:
-    response = await async_client.get(
-        "/api/v1/exchange_rates/USD/EUR/historical",
-        params={
-            "start_date": "2024-12-31",
-            "end_date": "2023-03-15",
+    assert_historical_exchange_rates_response(
+        response,
+        data_size=6,
+        first_data={
+            "rate": "0.98",
+            "date": "2024-10-10",
+        },
+        last_data={
+            "rate": "1",
+            "date": "2024-01-01",
         },
     )
-    assert response.status_code == 422
-    assert response.json() == {
-        "detail": "start_date must be before or equal to end_date",
-    }
 
 
 @pytest.mark.asyncio
@@ -175,25 +163,20 @@ async def test_api_v1_historical_exchange_rates_with_limit(
     response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"size": 2})
     assert response.status_code == 200
 
-    response_json = response.json()
-    assert response_json["base_currency_code"] == "USD"
-    assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 8
-    assert response_json["page"] == 1
-    assert response_json["size"] == 2
-    assert response_json["pages"] == 4
-
-    data = response_json["data"]
-    assert len(data) == 2
-
-    assert data[0] == {
-        "rate": "1.02",
-        "date": "2024-01-02",
-    }
-    assert data[-1] == {
-        "rate": "1",
-        "date": "2024-01-01",
-    }
+    assert_historical_exchange_rates_response(
+        response,
+        size=2,
+        data_size=2,
+        first_data={
+            "rate": "1.02",
+            "date": "2024-01-02",
+        },
+        last_data={
+            "rate": "1",
+            "date": "2024-01-01",
+        },
+        pages=4,
+    )
 
 
 @pytest.mark.asyncio
@@ -209,25 +192,21 @@ async def test_api_v1_historical_exchange_rates_with_offset_and_limit(
     response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"page": 2, "size": 2})
     assert response.status_code == 200
 
-    response_json = response.json()
-    assert response_json["base_currency_code"] == "USD"
-    assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 8
-    assert response_json["page"] == 2
-    assert response_json["size"] == 2
-    assert response_json["pages"] == 4
-
-    data = response_json["data"]
-    assert len(data) == 2
-
-    assert data[0] == {
-        "rate": "1.05",
-        "date": "2024-01-05",
-    }
-    assert data[-1] == {
-        "rate": "1.04",
-        "date": "2024-01-03",
-    }
+    assert_historical_exchange_rates_response(
+        response,
+        size=2,
+        data_size=2,
+        first_data={
+            "rate": "1.05",
+            "date": "2024-01-05",
+        },
+        last_data={
+            "rate": "1.04",
+            "date": "2024-01-03",
+        },
+        page=2,
+        pages=4,
+    )
 
 
 @pytest.mark.asyncio
@@ -243,25 +222,17 @@ async def test_api_v1_historical_exchange_rates_with_order_asc(
     response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"order": "asc"})
     assert response.status_code == 200
 
-    response_json = response.json()
-    assert response_json["base_currency_code"] == "USD"
-    assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 8
-    assert response_json["page"] == 1
-    assert response_json["size"] == 1000
-    assert response_json["pages"] == 1
-
-    data = response_json["data"]
-    assert len(data) == 5
-
-    assert data[0] == {
-        "rate": "1",
-        "date": "2024-01-01",
-    }
-    assert data[-1] == {
-        "rate": "1.12",
-        "date": "2024-04-02",
-    }
+    assert_historical_exchange_rates_response(
+        response,
+        first_data={
+            "rate": "1",
+            "date": "2024-01-01",
+        },
+        last_data={
+            "rate": "1.12",
+            "date": "2024-04-02",
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -277,25 +248,17 @@ async def test_api_v1_historical_exchange_rates_with_order_desc(
     response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical")
     assert response.status_code == 200
 
-    response_json = response.json()
-    assert response_json["base_currency_code"] == "USD"
-    assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 8
-    assert response_json["page"] == 1
-    assert response_json["size"] == 1000
-    assert response_json["pages"] == 1
-
-    data = response_json["data"]
-    assert len(data) == 5
-
-    assert data[0] == {
-        "rate": "1.12",
-        "date": "2024-04-02",
-    }
-    assert data[-1] == {
-        "rate": "1",
-        "date": "2024-01-01",
-    }
+    assert_historical_exchange_rates_response(
+        response,
+        first_data={
+            "rate": "1.12",
+            "date": "2024-04-02",
+        },
+        last_data={
+            "rate": "1",
+            "date": "2024-01-01",
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -311,25 +274,20 @@ async def test_api_v1_historical_exchange_rates_with_limit_and_order_asc(
     response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"size": 2, "order": "asc"})
     assert response.status_code == 200
 
-    response_json = response.json()
-    assert response_json["base_currency_code"] == "USD"
-    assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 8
-    assert response_json["page"] == 1
-    assert response_json["size"] == 2
-    assert response_json["pages"] == 4
-
-    data = response_json["data"]
-    assert len(data) == 2
-
-    assert data[0] == {
-        "rate": "1",
-        "date": "2024-01-01",
-    }
-    assert data[-1] == {
-        "rate": "1.02",
-        "date": "2024-01-02",
-    }
+    assert_historical_exchange_rates_response(
+        response,
+        data_size=2,
+        first_data={
+            "rate": "1",
+            "date": "2024-01-01",
+        },
+        last_data={
+            "rate": "1.02",
+            "date": "2024-01-02",
+        },
+        size=2,
+        pages=4,
+    )
 
 
 @pytest.mark.asyncio
@@ -357,6 +315,24 @@ async def test_api_v1_historical_exchange_rates_without_usd(
     response = await async_client.get("/api/v1/exchange_rates/JPY/EUR/historical")
     assert response.status_code == 422
     assert response.json() == {"detail": "At least one currency must be USD"}
+
+
+@pytest.mark.asyncio
+async def test_api_v1_historical_exchange_rates_with_start_date_after_end_date(
+    async_client: AsyncClient,
+    with_test_exchange_rate_service: ExchangeRateServiceInterface,
+) -> None:
+    response = await async_client.get(
+        "/api/v1/exchange_rates/USD/EUR/historical",
+        params={
+            "start_date": "2024-12-31",
+            "end_date": "2023-03-15",
+        },
+    )
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": "start_date must be before or equal to end_date",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/api/exchange_rates/test_historical_exchange_rates.py
+++ b/tests/api/exchange_rates/test_historical_exchange_rates.py
@@ -23,9 +23,9 @@ async def test_api_v1_historical_exchange_rates(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 5
+    assert response_json["total"] == 8
     assert response_json["page"] == 1
-    assert response_json["size"] == 5
+    assert response_json["size"] == 1000
     assert response_json["pages"] == 1
 
     data = response_json["data"]
@@ -57,9 +57,9 @@ async def test_api_v1_historical_exchange_rates_with_start_date(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 5
+    assert response_json["total"] == 8
     assert response_json["page"] == 1
-    assert response_json["size"] == 5
+    assert response_json["size"] == 1000
     assert response_json["pages"] == 1
 
     data = response_json["data"]
@@ -91,9 +91,9 @@ async def test_api_v1_historical_exchange_rates_with_end_date(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 5
+    assert response_json["total"] == 8
     assert response_json["page"] == 1
-    assert response_json["size"] == 5
+    assert response_json["size"] == 1000
     assert response_json["pages"] == 1
 
     data = response_json["data"]
@@ -126,9 +126,9 @@ async def test_api_v1_historical_exchange_rates_with_start_and_end_date(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 5
+    assert response_json["total"] == 8
     assert response_json["page"] == 1
-    assert response_json["size"] == 5
+    assert response_json["size"] == 1000
     assert response_json["pages"] == 1
 
     data = response_json["data"]
@@ -178,10 +178,10 @@ async def test_api_v1_historical_exchange_rates_with_limit(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 5
+    assert response_json["total"] == 8
     assert response_json["page"] == 1
     assert response_json["size"] == 2
-    assert response_json["pages"] == 3
+    assert response_json["pages"] == 4
 
     data = response_json["data"]
     assert len(data) == 2
@@ -212,10 +212,10 @@ async def test_api_v1_historical_exchange_rates_with_offset_and_limit(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 5
+    assert response_json["total"] == 8
     assert response_json["page"] == 2
     assert response_json["size"] == 2
-    assert response_json["pages"] == 3
+    assert response_json["pages"] == 4
 
     data = response_json["data"]
     assert len(data) == 2
@@ -246,9 +246,9 @@ async def test_api_v1_historical_exchange_rates_with_order_asc(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 5
+    assert response_json["total"] == 8
     assert response_json["page"] == 1
-    assert response_json["size"] == 5
+    assert response_json["size"] == 1000
     assert response_json["pages"] == 1
 
     data = response_json["data"]
@@ -280,9 +280,9 @@ async def test_api_v1_historical_exchange_rates_with_order_desc(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 5
+    assert response_json["total"] == 8
     assert response_json["page"] == 1
-    assert response_json["size"] == 5
+    assert response_json["size"] == 1000
     assert response_json["pages"] == 1
 
     data = response_json["data"]
@@ -314,10 +314,10 @@ async def test_api_v1_historical_exchange_rates_with_limit_and_order_asc(
     response_json = response.json()
     assert response_json["base_currency_code"] == "USD"
     assert response_json["quote_currency_code"] == "EUR"
-    assert response_json["total"] == 5
+    assert response_json["total"] == 8
     assert response_json["page"] == 1
     assert response_json["size"] == 2
-    assert response_json["pages"] == 3
+    assert response_json["pages"] == 4
 
     data = response_json["data"]
     assert len(data) == 2

--- a/tests/api/exchange_rates/test_historical_exchange_rates.py
+++ b/tests/api/exchange_rates/test_historical_exchange_rates.py
@@ -178,6 +178,66 @@ async def test_api_v1_historical_exchange_rates_with_limit(
 
 @pytest.mark.asyncio
 @patch("app.api.exchange_rates.historical_exchange_rates.date")
+async def test_api_v1_historical_exchange_rates_with_offset(
+    mock_date: MagicMock,
+    async_client: AsyncClient,
+    with_test_exchange_rate_service: ExchangeRateServiceInterface,
+) -> None:
+    fixed_date = date(2024, 4, 5)
+    mock_date.today.return_value = fixed_date
+
+    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"offset": 2})
+    assert response.status_code == 200
+
+    response_json = response.json()
+    assert response_json["base_currency_code"] == "USD"
+    assert response_json["quote_currency_code"] == "EUR"
+
+    data = response_json["data"]
+    assert len(data) == 3
+
+    assert data[0] == {
+        "rate": "1.12",
+        "date": "2024-04-02",
+    }
+    assert data[-1] == {
+        "rate": "1.04",
+        "date": "2024-01-03",
+    }
+
+
+@pytest.mark.asyncio
+@patch("app.api.exchange_rates.historical_exchange_rates.date")
+async def test_api_v1_historical_exchange_rates_with_offset_and_limit(
+    mock_date: MagicMock,
+    async_client: AsyncClient,
+    with_test_exchange_rate_service: ExchangeRateServiceInterface,
+) -> None:
+    fixed_date = date(2024, 4, 5)
+    mock_date.today.return_value = fixed_date
+
+    response = await async_client.get("/api/v1/exchange_rates/USD/EUR/historical", params={"offset": 2, "limit": 2})
+    assert response.status_code == 200
+
+    response_json = response.json()
+    assert response_json["base_currency_code"] == "USD"
+    assert response_json["quote_currency_code"] == "EUR"
+
+    data = response_json["data"]
+    assert len(data) == 2
+
+    assert data[0] == {
+        "rate": "1.05",
+        "date": "2024-01-05",
+    }
+    assert data[-1] == {
+        "rate": "1.04",
+        "date": "2024-01-03",
+    }
+
+
+@pytest.mark.asyncio
+@patch("app.api.exchange_rates.historical_exchange_rates.date")
 async def test_api_v1_historical_exchange_rates_with_order_asc(
     mock_date: MagicMock,
     async_client: AsyncClient,

--- a/tests/api/exchange_rates/test_historical_exchange_rates.py
+++ b/tests/api/exchange_rates/test_historical_exchange_rates.py
@@ -9,8 +9,8 @@ from app.services.exchange_rate_service import ExchangeRateServiceInterface
 
 def assert_historical_exchange_rates_response(
     response: Response,
-    first_data: dict,
-    last_data: dict,
+    first_data: dict[str, str],
+    last_data: dict[str, str],
     total: int = 8,
     data_size: int = 5,
     size: int = 1000,

--- a/tests/services/test_exchange_rate_service.py
+++ b/tests/services/test_exchange_rate_service.py
@@ -152,7 +152,7 @@ async def test_get_historical_rates_success() -> None:
     start_date = date(2023, 1, 1)
 
     service = ExchangeRateService()
-    results = await service.get_historical_rates(
+    results, total = await service.get_historical_rates(
         base_currency_code=base_currency_code, quote_currency_code=quote_currency_code, start_date=start_date
     )
 
@@ -163,6 +163,8 @@ async def test_get_historical_rates_success() -> None:
     assert quantize_decimal(results[1].rate) == quantize_decimal("0.87")
     assert results[1].as_of == date(2023, 1, 20)
 
+    assert total == 2
+
 
 @pytest.mark.asyncio
 async def test_get_historical_rates_not_found() -> None:
@@ -171,11 +173,12 @@ async def test_get_historical_rates_not_found() -> None:
     start_date = date(2023, 1, 1)
 
     service = ExchangeRateService()
-    results = await service.get_historical_rates(
+    results, total = await service.get_historical_rates(
         base_currency_code=base_currency_code, quote_currency_code=quote_currency_code, start_date=start_date
     )
 
     assert results == []
+    assert total == 0
 
 
 @pytest.mark.asyncio
@@ -186,7 +189,7 @@ async def test_get_historical_rates_with_limit() -> None:
     limit = 1
 
     service = ExchangeRateService()
-    results = await service.get_historical_rates(
+    results, total = await service.get_historical_rates(
         base_currency_code=base_currency_code,
         quote_currency_code=quote_currency_code,
         start_date=start_date,
@@ -196,6 +199,7 @@ async def test_get_historical_rates_with_limit() -> None:
     assert len(results) == 1
     assert quantize_decimal(results[0].rate) == quantize_decimal("0.85")
     assert results[0].as_of == date(2023, 1, 1)
+    assert total == 2
 
 
 @pytest.mark.asyncio
@@ -206,7 +210,7 @@ async def test_get_historical_rates_with_sort_order_desc() -> None:
     sort_order: Literal["desc", "asc"] = "desc"
 
     service = ExchangeRateService()
-    results = await service.get_historical_rates(
+    results, total = await service.get_historical_rates(
         base_currency_code=base_currency_code,
         quote_currency_code=quote_currency_code,
         start_date=start_date,
@@ -215,6 +219,7 @@ async def test_get_historical_rates_with_sort_order_desc() -> None:
 
     assert len(results) == 2
     assert results[0].as_of > results[1].as_of
+    assert total == 2
 
 
 @pytest.mark.asyncio

--- a/tests/support/mock_exchange_rate_service.py
+++ b/tests/support/mock_exchange_rate_service.py
@@ -62,7 +62,7 @@ class MockExchangeRateService(ExchangeRateServiceInterface):
         limit: int | None = None,
         offset: int | None = None,
         sort_order: Literal["asc", "desc"] = "asc",
-    ) -> list[ExchangeRate]:
+    ) -> tuple[list[ExchangeRate], int]:
         rates = [
             build_exchange_rate(
                 as_of=date(2024, 1, 1),
@@ -113,6 +113,7 @@ class MockExchangeRateService(ExchangeRateServiceInterface):
                 rate=Decimal("0.92000000"),
             ),
         ]
+        total = len(rates)
 
         if start_date is not None:
             rates = [rate for rate in rates if rate.as_of >= start_date]
@@ -129,4 +130,4 @@ class MockExchangeRateService(ExchangeRateServiceInterface):
         if sort_order == "desc":
             rates.reverse()
 
-        return rates
+        return rates, total

--- a/tests/support/mock_exchange_rate_service.py
+++ b/tests/support/mock_exchange_rate_service.py
@@ -60,6 +60,7 @@ class MockExchangeRateService(ExchangeRateServiceInterface):
         start_date: date | None = None,
         end_date: date | None = None,
         limit: int | None = None,
+        offset: int | None = None,
         sort_order: Literal["asc", "desc"] = "asc",
     ) -> list[ExchangeRate]:
         rates = [
@@ -118,6 +119,9 @@ class MockExchangeRateService(ExchangeRateServiceInterface):
 
         if end_date is not None:
             rates = [rate for rate in rates if rate.as_of <= end_date]
+
+        if offset is not None:
+            rates = rates[offset:]
 
         if limit is not None:
             rates = rates[:limit]

--- a/tests/tasks/test_notifications.py
+++ b/tests/tasks/test_notifications.py
@@ -28,7 +28,7 @@ async def test_send_exchange_rate_refresh_email_success() -> None:
         rate=Decimal("0.72"),
     )
 
-    mock_exchange_rate_service.get_historical_rates.return_value = [latest_rate, previous_rate]
+    mock_exchange_rate_service.get_historical_rates.return_value = [latest_rate, previous_rate], 2
 
     with (
         patch("app.tasks.notifications.email_settings") as mock_email_settings,
@@ -88,7 +88,7 @@ async def test_send_exchange_rate_refresh_email_not_enough_rates() -> None:
         quote_currency_code=Currency("USD"),
         rate=Decimal("0.75"),
     )
-    mock_exchange_rate_service.get_historical_rates.return_value = [latest_rate]
+    mock_exchange_rate_service.get_historical_rates.return_value = [latest_rate], 1
 
     with (
         patch("app.tasks.notifications.email_settings") as mock_email_settings,
@@ -108,7 +108,7 @@ async def test_send_exchange_rate_refresh_email_not_enough_rates() -> None:
 async def test_send_exchange_rate_refresh_email_empty_rates() -> None:
     mock_exchange_rate_service = AsyncMock(spec=ExchangeRateServiceInterface)
 
-    mock_exchange_rate_service.get_historical_rates.return_value = []
+    mock_exchange_rate_service.get_historical_rates.return_value = [], 0
 
     with (
         patch("app.tasks.notifications.email_settings") as mock_email_settings,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pagination to the historical exchange rates API, allowing users to specify page number and page size when retrieving data.
  - The API response now includes pagination metadata: total records, current page, page size, and total pages.
  - Added a redirect from the root URL ("/") to the API documentation page.

- **Bug Fixes**
  - Improved validation for date ranges and page size parameters in the historical exchange rates API.

- **Chores**
  - Enhanced test coverage and maintainability by centralizing response validation and updating tests to reflect new pagination features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->