### PR TITLE
Match Celery worker timezone to environment

### DIFF
--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -28,6 +28,7 @@ celery_app.conf.update(
     worker_prefetch_multiplier=1,  # Don't prefetch more tasks than workers can handle
     task_send_sent_event=True,  # Required for monitoring task queue length in Flower
     result_expires=60 * 60 * 24,  # Results expire after 24 hours
+    timezone=celery_settings.timezone,
 )
 
 

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -29,6 +29,7 @@ celery_app.conf.update(
     task_send_sent_event=True,  # Required for monitoring task queue length in Flower
     result_expires=60 * 60 * 24,  # Results expire after 24 hours
     timezone=celery_settings.timezone,
+    enable_utc=celery_settings.timezone == "UTC",
 )
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -118,6 +118,10 @@ class CelerySettings(BaseSettings):
     def exchange_rates_refresh_minute(self) -> str:
         return os.getenv("EXCHANGE_RATES_REFRESH_MINUTE", "00")
 
+    @property
+    def timezone(self) -> str:
+        return os.getenv("TZ", "UTC")
+
 
 celery_settings = CelerySettings()
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -120,7 +120,7 @@ class CelerySettings(BaseSettings):
 
     @property
     def timezone(self) -> str:
-        return os.getenv("TZ", "UTC")
+        return settings.timezone
 
 
 celery_settings = CelerySettings()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the Celery application's timezone based on environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->