### PR TITLE
Use standard timezone env var

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
 # Application
 ENV=production
 API_WORKERS=4 # Number of FastAPI worker processes
+TZ=Asia/Singapore # Optional, defaults to UTC
 
 # Database
 POSTGRES_HOST=postgres

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
 
     @property
     def timezone(self) -> str:
-        return os.getenv("TIMEZONE", "UTC")
+        return os.getenv("TZ", "UTC")
 
     @property
     def logging_level(self) -> str:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new optional timezone environment variable (`TZ`) with a default fallback to UTC.
  - Updated configuration to use the new `TZ` variable for timezone settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->